### PR TITLE
Add page1 refresh script and improve scraping

### DIFF
--- a/oemoem/page1_refresh.py
+++ b/oemoem/page1_refresh.py
@@ -1,0 +1,18 @@
+from master_refresh import InventoryRefresher
+
+"""Quick refresh script that scrapes only the first page of the eBay store.
+This is useful for testing scraping changes without waiting for the full
+inventory refresh."""
+
+
+def main():
+    refresher = InventoryRefresher()
+    refresher.scrape_ebay_parts(max_pages=1)
+    refresher.save_combined_listing_csv()
+    refresher.process_vin_matching()
+    refresher.organize_inventory_data()
+    refresher.save_inventory_json()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow specifying max pages to scrape
- capture all images and skip stock thumbnails
- refresh donor car data from scratch
- add `page1_refresh.py` for quick test runs

## Testing
- `python oemoem/test_workflow.py` *(fails: Combined Listing CSV missing)*

------
https://chatgpt.com/codex/tasks/task_e_688242d7dbd48328bbc923761b08c569